### PR TITLE
Implement general album_view and do some code janitoring

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,38 @@
+﻿---
+BasedOnStyle: WebKit
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: 'true'
+AlignConsecutiveAssignments: 'true'
+AlignConsecutiveDeclarations: 'false'
+AlignOperands: 'true'
+AlignTrailingComments: 'true'
+AllowAllArgumentsOnNextLine: 'true'
+AllowAllConstructorInitializersOnNextLine: 'true'
+AllowAllParametersOfDeclarationOnNextLine: 'true'
+AllowShortBlocksOnASingleLine: 'true'
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: 'Yes'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakBeforeBraces: Allman
+ColumnLimit: '120'
+FixNamespaceComments: 'true'
+IndentCaseLabels: 'false'
+IndentPPDirectives: BeforeHash
+IndentWidth: '4'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+NamespaceIndentation: All
+PointerAlignment: Left
+SortIncludes: 'true'
+SpacesInContainerLiterals: 'false'
+SpacesInParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+Standard: Cpp11
+TabWidth: '4'
+UseTab: Never
+
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,32 @@
+---
+Checks: "*,
+        -abseil-*,
+        -altera-*,
+        -android-*,
+        -fuchsia-*,
+        -google-*,
+        -llvm*,
+        -modernize-use-trailing-return-type,
+        -zircon-*,
+        -readability-else-after-return,
+        -readability-static-accessed-through-instance,
+        -readability-avoid-const-params-in-decls,
+        -cppcoreguidelines-non-private-member-variables-in-classes,
+        -misc-non-private-member-variables-in-classes,
+        -misc-no-recursion,
+        -misc-use-anonymous-namespace,
+        -misc-use-internal-linkage
+"
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle:     none
+
+CheckOptions:
+  - key: readability-identifier-length.IgnoredVariableNames
+    value: 'x|y|z'
+  - key: readability-identifier-length.IgnoredParameterNames
+    value: 'x|y|z'
+
+
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cache/
 build/
+compile_commands.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "ext/cryptopp-cmake"]
 	path = ext/cryptopp-cmake
 	url = https://github.com/abdes/cryptopp-cmake.git
+[submodule "ext/cryptopp"]
+	path = ext/cryptopp
+	url = https://github.com/weidai11/cryptopp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 4.0)
 project(sonicli
         VERSION 0.0.1)
 
-set(CXX_STANDARD 23)
-
 set(NLOHMANN_JSON_BUILD_MODULES ON)
 add_subdirectory(ext/json)
 
@@ -24,9 +22,11 @@ add_executable(sonicli
     src/oss/data/subsonic_response.cpp
     src/oss/endpoints.cpp
     src/oss/server_config.cpp
+    src/ui/album_view.cpp
     src/ui/debug_view.cpp
     src/ui/login_component.cpp
 )
+
 target_include_directories(sonicli PRIVATE
     inc/
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,18 +2,46 @@ cmake_minimum_required(VERSION 4.0)
 project(sonicli
         VERSION 0.0.1)
 
+include(FetchContent)
+
 set(NLOHMANN_JSON_BUILD_MODULES ON)
-add_subdirectory(ext/json)
-
-add_subdirectory(ext/cpr)
-
+FetchContent_Declare(nlohmann_json
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ext/json
+    BINARY_DIR ${CMAKE_BINARY_DIR}/ext/json
+    OVERRIDE_FIND_PACKAGE
+    SYSTEM
+    CMAKE_ARGS
+        NLOHMANN_JSON_BUILD_MODULES ON
+)
+FetchContent_MakeAvailable(nlohmann_json)
+FetchContent_Declare(cpr
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ext/cpr
+    BINARY_DIR ${CMAKE_BINARY_DIR}/ext/cpr
+    OVERRIDE_FIND_PACKAGE
+    SYSTEM
+)
+FetchContent_MakeAvailable(cpr)
 set(FTXUI_BUILD_MODULES ON)
-add_subdirectory(ext/FTXUI)
+FetchContent_Declare(ftxui
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ext/FTXUI
+    BINARY_DIR ${CMAKE_BINARY_DIR}/ext/FTXUI
+    OVERRIDE_FIND_PACKAGE
+    SYSTEM
+    CMAKE_ARGS
+        NLOHMANN_JSON_BUILD_MODULES ON
+)
+FetchContent_MakeAvailable(ftxui)
 
+set(CRYPTOPP_BUILD_TESTING OFF CACHE BOOL INTERNAL)
+FetchContent_Declare(cryptopp
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ext/cryptopp-cmake
+    BINARY_DIR ${CMAKE_BINARY_DIR}/ext/cryptopp-cmake
+    OVERRIDE_FIND_PACKAGE
+    SYSTEM
+)
+FetchContent_MakeAvailable(cryptopp)
 
-set(CRYPTOPP_ENABLE_NAMESPACE_WEAK 1)
-set(CRYPTOPP_BUILD_TESTING OFF)
-add_subdirectory(ext/cryptopp-cmake)
+find_package(ftxui REQUIRED)
 
 add_executable(sonicli
     src/main.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ add_executable(sonicli
     src/oss/endpoints.cpp
     src/oss/server_config.cpp
     src/ui/album_view.cpp
-    src/ui/debug_view.cpp
     src/ui/login_component.cpp
 )
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,32 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 4,
+    "minor": 0,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "hidden": false,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "TRUE",
+        "CRYPTOPP_SOURCES": "ext/cryptopp"
+      }
+    },
+    {
+      "name": "debug",
+      "hidden": false,
+      "binaryDir": "${sourceDir}/build-debug",
+      "inherits": ["default"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    }
+  ]
+}

--- a/inc/crypto/md5.hpp
+++ b/inc/crypto/md5.hpp
@@ -5,7 +5,6 @@
 #include <span>
 #include <string>
 
-
 namespace crypto
 {
     std::optional<std::string> md5_digest(const std::span<const uint8_t> data);

--- a/inc/crypto/password.hpp
+++ b/inc/crypto/password.hpp
@@ -7,23 +7,17 @@ namespace crypto
     class password
     {
     public:
-        password(const std::string_view pass_str);
+        explicit password(const std::string_view pass_str);
 
-        inline const std::string& hash() const
-        {
-            return mHash;
-        }
+        [[nodiscard]] const std::string& hash() const { return mHash; }
+        [[nodiscard]] const std::string& salt() const { return mSalt; }
 
-        inline const std::string& salt() const
-        {
-            return mSalt;
-        }
+        [[nodiscard]] static std::string generate_salt();
 
     private:
-        std::string hash_password(const std::string_view pass_str) const;
-        std::string generate_salt() const;
+        [[nodiscard]] std::string hash_password(const std::string_view pass_str) const;
 
-        std::string mSalt{this->generate_salt()};
-        std::string mHash{};
+        std::string mSalt { this->generate_salt() };
+        std::string mHash;
     };
-}
+} // namespace crypto

--- a/inc/oss/data/subsonic_response.hpp
+++ b/inc/oss/data/subsonic_response.hpp
@@ -47,6 +47,7 @@ namespace oss::data
 
     struct music_track
     {
+        std::string id{};
         std::string title{};
         friend void from_json(const json& j, music_track& m);
     };

--- a/inc/oss/data/subsonic_response.hpp
+++ b/inc/oss/data/subsonic_response.hpp
@@ -13,69 +13,69 @@ namespace oss::data
         int code;
         std::optional<std::string> message;
 
-        friend void to_json(json& j, const subsonic_error& err);
-        friend void from_json(const json& j, subsonic_error& err);
+        friend void to_json(json& obj, const subsonic_error& err);
+        friend void from_json(const json& obj, subsonic_error& err);
     };
 
     struct subsonic_response
     {
-        std::string status { "" };
-        std::string version { "" };
-        std::string type { "" };
-        std::string serverVersion { "" };
+        std::string status;
+        std::string version;
+        std::string type;
+        std::string serverVersion;
         bool openSubsonic { false };
         std::optional<subsonic_error> error;
 
-        friend void to_json(json& j, const subsonic_response& p);
-        friend void from_json(const json& j, subsonic_response& p);
+        friend void to_json(json& obj, const subsonic_response& res);
+        friend void from_json(const json& obj, subsonic_response& res);
     };
 
     struct music_folder
     {
         int id;
-        std::string name {};
+        std::string name;
 
-        friend void to_json(json& j, const music_folder& m);
-        friend void from_json(const json& j, music_folder& m);
+        friend void to_json(json& obj, const music_folder& mfolder);
+        friend void from_json(const json& obj, music_folder& mfolder);
     };
 
     struct music_folder_response : public subsonic_response
     {
         std::optional<std::vector<music_folder>> music_folders;
-        friend void from_json(const json& j, music_folder_response& m);
+        friend void from_json(const json& obj, music_folder_response& res);
     };
 
     struct music_track
     {
-        std::string id {};
-        std::string title {};
-        friend void from_json(const json& j, music_track& m);
+        std::string id;
+        std::string title;
+        friend void from_json(const json& obj, music_track& track);
     };
 
     struct album_list
     {
         std::vector<music_track> album;
-        friend void from_json(const json& j, album_list& a);
+        friend void from_json(const json& obj, album_list& album);
     };
 
     struct album_list_response : public subsonic_response
     {
         std::optional<album_list> album_list;
-        friend void from_json(const json& j, album_list_response& a);
+        friend void from_json(const json& obj, album_list_response& res);
     };
 
     struct album_id3
     {
-        std::string id {};
-        std::string name {};
-        std::optional<std::vector<music_track>> children {};
-        friend void from_json(const json& j, album_id3& a);
+        std::string id;
+        std::string name;
+        std::optional<std::vector<music_track>> children;
+        friend void from_json(const json& obj, album_id3& aid);
     };
 
     struct album_response : public subsonic_response
     {
-        std::optional<album_id3> album {};
-        friend void from_json(const json& j, album_response& a);
+        std::optional<album_id3> album;
+        friend void from_json(const json& obj, album_response& res);
     };
 
 } // namespace oss::data

--- a/inc/oss/data/subsonic_response.hpp
+++ b/inc/oss/data/subsonic_response.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
-#include <nlohmann/json.hpp>
 
 import nlohmann.json;
 namespace oss::data
@@ -19,11 +19,11 @@ namespace oss::data
 
     struct subsonic_response
     {
-        std::string status{""};
-        std::string version{""};
-        std::string type{""};
-        std::string serverVersion{""};
-        bool openSubsonic{false};
+        std::string status { "" };
+        std::string version { "" };
+        std::string type { "" };
+        std::string serverVersion { "" };
+        bool openSubsonic { false };
         std::optional<subsonic_error> error;
 
         friend void to_json(json& j, const subsonic_response& p);
@@ -33,7 +33,7 @@ namespace oss::data
     struct music_folder
     {
         int id;
-        std::string name{};
+        std::string name {};
 
         friend void to_json(json& j, const music_folder& m);
         friend void from_json(const json& j, music_folder& m);
@@ -47,8 +47,8 @@ namespace oss::data
 
     struct music_track
     {
-        std::string id{};
-        std::string title{};
+        std::string id {};
+        std::string title {};
         friend void from_json(const json& j, music_track& m);
     };
 
@@ -64,4 +64,18 @@ namespace oss::data
         friend void from_json(const json& j, album_list_response& a);
     };
 
-}
+    struct album_id3
+    {
+        std::string id {};
+        std::string name {};
+        std::vector<music_track> children {};
+        friend void from_json(const json& j, album_id3& a);
+    };
+
+    struct album_response : public subsonic_response
+    {
+        std::optional<album_id3> album {};
+        friend void from_json(const json& j, album_response& a);
+    };
+
+} // namespace oss::data

--- a/inc/oss/data/subsonic_response.hpp
+++ b/inc/oss/data/subsonic_response.hpp
@@ -68,7 +68,7 @@ namespace oss::data
     {
         std::string id {};
         std::string name {};
-        std::vector<music_track> children {};
+        std::optional<std::vector<music_track>> children {};
         friend void from_json(const json& j, album_id3& a);
     };
 

--- a/inc/oss/data/subsonic_response.hpp
+++ b/inc/oss/data/subsonic_response.hpp
@@ -51,4 +51,16 @@ namespace oss::data
         friend void from_json(const json& j, music_track& m);
     };
 
+    struct album_list
+    {
+        std::vector<music_track> album;
+        friend void from_json(const json& j, album_list& a);
+    };
+
+    struct album_list_response : public subsonic_response
+    {
+        std::optional<album_list> album_list;
+        friend void from_json(const json& j, album_list_response& a);
+    };
+
 }

--- a/inc/oss/endpoints.hpp
+++ b/inc/oss/endpoints.hpp
@@ -8,4 +8,5 @@ namespace oss
 {
     std::optional<data::subsonic_response> ping(const server_config& config);
     std::optional<data::music_folder_response> getMusicFolders(const server_config& config);
+    std::optional<data::album_list_response> getAlbumList(const server_config& config);
 }

--- a/inc/oss/endpoints.hpp
+++ b/inc/oss/endpoints.hpp
@@ -10,4 +10,5 @@ namespace oss
     std::optional<data::music_folder_response> getMusicFolders(const server_config& config);
     std::optional<data::album_list_response> getAlbumList(const server_config& config);
     std::optional<data::album_response> getAlbum(const server_config& config, const std::string& album_id);
+    std::optional<std::vector<data::album_response>> getAlbum(const server_config& config, const std::vector<data::music_track>& albums_list);
 }

--- a/inc/oss/endpoints.hpp
+++ b/inc/oss/endpoints.hpp
@@ -10,5 +10,6 @@ namespace oss
     std::optional<data::music_folder_response> getMusicFolders(const server_config& config);
     std::optional<data::album_list_response> getAlbumList(const server_config& config);
     std::optional<data::album_response> getAlbum(const server_config& config, const std::string& album_id);
-    std::optional<std::vector<data::album_response>> getAlbum(const server_config& config, const std::vector<data::music_track>& albums_list);
-}
+    std::optional<std::vector<data::album_response>> getAlbum(const server_config& config,
+                                                              const std::vector<data::music_track>& albums_list);
+} // namespace oss

--- a/inc/oss/endpoints.hpp
+++ b/inc/oss/endpoints.hpp
@@ -9,4 +9,5 @@ namespace oss
     std::optional<data::subsonic_response> ping(const server_config& config);
     std::optional<data::music_folder_response> getMusicFolders(const server_config& config);
     std::optional<data::album_list_response> getAlbumList(const server_config& config);
+    std::optional<data::album_response> getAlbum(const server_config& config, const std::string& album_id);
 }

--- a/inc/oss/server_config.hpp
+++ b/inc/oss/server_config.hpp
@@ -10,16 +10,16 @@ namespace oss
 {
     namespace
     {
-        constexpr static std::string_view client_id{"sonicli/0.0.1"};
+        constexpr std::string_view client_id { "sonicli/0.0.1" };
     }
     struct server_config
     {
-        server_config(const std::string& user, const std::string& url);
+        server_config(std::string user, std::string url);
         std::optional<std::string> login();
 
-        std::string url_string{};
-        std::string user{};
-        std::unique_ptr<crypto::password> password{nullptr};
-        std::unique_ptr<cpr::Parameters> parameters{std::make_unique<cpr::Parameters>()};
+        std::string url_string;
+        std::string user;
+        std::unique_ptr<crypto::password> password { nullptr };
+        std::unique_ptr<cpr::Parameters> parameters { std::make_unique<cpr::Parameters>() };
     };
-}
+} // namespace oss

--- a/inc/ui/album_view.hpp
+++ b/inc/ui/album_view.hpp
@@ -21,7 +21,7 @@ namespace ui
         int mTrackSelected { 0 };
         std::vector<std::string> mAlbumTitles { get_albums() };
         std::vector<std::vector<std::string>> mAlbumTracks { get_albums_tracks() };
-        std::vector<std::string> mCurrentAlbumTracks{mAlbumTracks[0]};
+        std::vector<std::string> mCurrentAlbumTracks { mAlbumTracks[0] };
 
         ftxui::MenuOption albumOption { .entries   = &mAlbumTitles,
                                         .selected  = &mAlbumSelected,

--- a/inc/ui/album_view.hpp
+++ b/inc/ui/album_view.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "oss/server_config.hpp"
+#include <ftxui/component/component_options.hpp>
 import ftxui;
 
 namespace ui
@@ -8,8 +9,7 @@ namespace ui
     {
     public:
         album_view(ftxui::ScreenInteractive& screen, oss::server_config& config);
-        ftxui::Element render();
-        inline ftxui::Component component() { return mContainer; }
+        ftxui::Component render();
 
     private:
         std::vector<std::string> get_albums();
@@ -18,11 +18,20 @@ namespace ui
         oss::server_config* mConfig { nullptr };
 
         int mAlbumSelected { 0 };
+        int mTrackSelected { 0 };
         std::vector<std::string> mAlbumTitles { get_albums() };
-        std::vector<std::vector<std::string>> mAlbumTracks {};
+        std::vector<std::vector<std::string>> mAlbumTracks { get_albums_tracks() };
+        std::vector<std::string> mCurrentAlbumTracks {};
 
-        ftxui::Component mAlbumMenu { ftxui::Menu({ .entries = &mAlbumTitles, .selected = mAlbumSelected }) };
-        ftxui::Component mTrackMenu { ftxui::Menu({ .entries = &mAlbumTitles, .selected = mAlbumSelected }) };
+        ftxui::MenuOption albumOption { .entries   = &mAlbumTitles,
+                                        .selected  = &mAlbumSelected,
+                                        .on_change = [&]()
+                                        {
+                                            mTrackSelected      = 0;
+                                            mCurrentAlbumTracks = mAlbumTracks[mAlbumSelected];
+                                        } };
+        ftxui::Component mAlbumMenu { ftxui::Menu(albumOption) };
+        ftxui::Component mTrackMenu { ftxui::Menu({ .entries = &mCurrentAlbumTracks, .selected = &mTrackSelected }) };
         ftxui::Component mContainer { ftxui::Container::Horizontal({ mAlbumMenu, mTrackMenu }) };
     };
 } // namespace ui

--- a/inc/ui/album_view.hpp
+++ b/inc/ui/album_view.hpp
@@ -21,7 +21,7 @@ namespace ui
         int mTrackSelected { 0 };
         std::vector<std::string> mAlbumTitles { get_albums() };
         std::vector<std::vector<std::string>> mAlbumTracks { get_albums_tracks() };
-        std::vector<std::string> mCurrentAlbumTracks;
+        std::vector<std::string> mCurrentAlbumTracks{mAlbumTracks[0]};
 
         ftxui::MenuOption albumOption { .entries   = &mAlbumTitles,
                                         .selected  = &mAlbumSelected,

--- a/inc/ui/album_view.hpp
+++ b/inc/ui/album_view.hpp
@@ -21,7 +21,7 @@ namespace ui
         int mTrackSelected { 0 };
         std::vector<std::string> mAlbumTitles { get_albums() };
         std::vector<std::vector<std::string>> mAlbumTracks { get_albums_tracks() };
-        std::vector<std::string> mCurrentAlbumTracks {};
+        std::vector<std::string> mCurrentAlbumTracks;
 
         ftxui::MenuOption albumOption { .entries   = &mAlbumTitles,
                                         .selected  = &mAlbumSelected,

--- a/inc/ui/album_view.hpp
+++ b/inc/ui/album_view.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "oss/server_config.hpp"
+import ftxui;
+
+namespace ui
+{
+    class album_view
+    {
+    public:
+        album_view(ftxui::ScreenInteractive& screen, oss::server_config& config);
+        ftxui::Element render();
+        inline ftxui::Component component() { return mContainer; }
+
+    private:
+        std::vector<std::string> get_albums();
+        std::vector<std::vector<std::string>> get_albums_tracks();
+        [[maybe_unused]] ftxui::ScreenInteractive* mScreen { nullptr };
+        oss::server_config* mConfig { nullptr };
+
+        int mAlbumSelected { 0 };
+        std::vector<std::string> mAlbumTitles { get_albums() };
+        std::vector<std::vector<std::string>> mAlbumTracks {};
+
+        ftxui::Component mAlbumMenu { ftxui::Menu({ .entries = &mAlbumTitles, .selected = mAlbumSelected }) };
+        ftxui::Component mTrackMenu { ftxui::Menu({ .entries = &mAlbumTitles, .selected = mAlbumSelected }) };
+        ftxui::Component mContainer { ftxui::Container::Horizontal({ mAlbumMenu, mTrackMenu }) };
+    };
+} // namespace ui

--- a/inc/ui/debug_view.hpp
+++ b/inc/ui/debug_view.hpp
@@ -17,6 +17,7 @@ namespace ui
     private:
         void ping();
         void musicFolders();
+        void albumList();
         std::string mDebugText{""};
 
         int mIndex{0};
@@ -25,6 +26,7 @@ namespace ui
         ftxui::Component mQuit{ftxui::Button("Quit", [&]{ mScreen->Exit(); })};
         ftxui::Component mPing{ftxui::Button("Ping!", [&]{ this->ping(); })};
         ftxui::Component mMusicFolders{ftxui::Button("MusicFolders", [&]{ this->musicFolders(); })};
+        ftxui::Component mAlbumList{ftxui::Button("AlbumList", [&]{ this->albumList(); })};
         ftxui::Component mContainer;
     };
 }

--- a/inc/ui/debug_view.hpp
+++ b/inc/ui/debug_view.hpp
@@ -9,24 +9,21 @@ namespace ui
     public:
         debug_view(ftxui::ScreenInteractive& screen, oss::server_config& config);
         ftxui::Element render();
-        inline ftxui::Component component()
-        {
-            return mContainer;
-        }
+        inline ftxui::Component component() { return mContainer; }
 
     private:
         void ping();
         void musicFolders();
         void albumList();
-        std::string mDebugText{""};
+        std::string mDebugText { "" };
 
-        int mIndex{0};
-        oss::server_config* mConfig{nullptr};
-        ftxui::ScreenInteractive* mScreen{nullptr};
-        ftxui::Component mQuit{ftxui::Button("Quit", [&]{ mScreen->Exit(); })};
-        ftxui::Component mPing{ftxui::Button("Ping!", [&]{ this->ping(); })};
-        ftxui::Component mMusicFolders{ftxui::Button("MusicFolders", [&]{ this->musicFolders(); })};
-        ftxui::Component mAlbumList{ftxui::Button("AlbumList", [&]{ this->albumList(); })};
+        int mIndex { 0 };
+        oss::server_config* mConfig { nullptr };
+        ftxui::ScreenInteractive* mScreen { nullptr };
+        ftxui::Component mQuit { ftxui::Button("Quit", [&] { mScreen->Exit(); }) };
+        ftxui::Component mPing { ftxui::Button("Ping!", [&] { this->ping(); }) };
+        ftxui::Component mMusicFolders { ftxui::Button("MusicFolders", [&] { this->musicFolders(); }) };
+        ftxui::Component mAlbumList { ftxui::Button("AlbumList", [&] { this->albumList(); }) };
         ftxui::Component mContainer;
     };
-}
+} // namespace ui

--- a/inc/ui/login_component.hpp
+++ b/inc/ui/login_component.hpp
@@ -13,28 +13,24 @@ namespace ui
     public:
         login_component(ftxui::ScreenInteractive& screen, oss::server_config& config);
         ftxui::Element render();
-        inline ftxui::Component component()
-        {
-            return mContainer;
-        }
-    private:
-        ftxui::ScreenInteractive* mScreen{nullptr};
-        std::vector<std::string> entries{"login"};
-        int index{0};
-        int buttonIndex{0};
-        oss::server_config* mConfig{nullptr};
-        bool mConnection{false};
-        std::string serverText{""};
-        std::string mPassword{""};
+        ftxui::Component component() { return mContainer; }
 
-        ftxui::Component mUserNameInput{ftxui::Input(&mConfig->user, "username")};
-        ftxui::Component mPasswordInput{ftxui::Input(&mPassword, "", {.password = true})};
-        ftxui::Component mURLInput{ftxui::Input(&mConfig->url_string, "https://")};
-        ftxui::Component mQuit{ftxui::Button("Quit", [&]{ mScreen->Exit(); })};
+    private:
+        ftxui::ScreenInteractive* mScreen { nullptr };
+        std::vector<std::string> entries { "login" };
+        int index { 0 };
+        int buttonIndex { 0 };
+        oss::server_config* mConfig { nullptr };
+        bool mConnection { false };
+        std::string serverText;
+        std::string mPassword;
+
+        ftxui::Component mUserNameInput { ftxui::Input(&mConfig->user, "username") };
+        ftxui::Component mPasswordInput { ftxui::Input(&mPassword, "", { .password = true }) };
+        ftxui::Component mURLInput { ftxui::Input(&mConfig->url_string, "https://") };
+        ftxui::Component mQuit { ftxui::Button("Quit", [&] { mScreen->Exit(); }) };
         ftxui::Component mSubmit;
 
         ftxui::Component mContainer;
     };
-}
-
-
+} // namespace ui

--- a/src/crypto/md5.cpp
+++ b/src/crypto/md5.cpp
@@ -1,29 +1,29 @@
 #include "crypto/md5.hpp"
 #include <optional>
 #define CRYPTOPP_ENABLE_NAMESPACE_WEAK 1
-#include <cryptopp/md5.h>
 #include <cryptopp/hex.h>
+#include <cryptopp/md5.h>
 
 namespace crypto
 {
     using namespace CryptoPP;
     std::optional<std::string> md5_digest(const std::span<const uint8_t> data)
     {
-        std::array<CryptoPP::byte, CryptoPP::Weak::MD5::DIGESTSIZE> digest{};
+        std::array<CryptoPP::byte, CryptoPP::Weak::MD5::DIGESTSIZE> digest {};
         Weak::MD5 hash;
         hash.CalculateDigest(&digest.front(), data.data(), data.size());
-        HexEncoder encoder{nullptr, false};
+        HexEncoder encoder { nullptr, false };
         encoder.Put(digest.data(), digest.size());
         encoder.MessageEnd();
 
-        const auto size{encoder.MaxRetrievable()};
-        if (size)
+        const auto size { encoder.MaxRetrievable() };
+        if (size != 0U)
         {
-            std::string encoded{};
+            std::string encoded {};
             encoded.resize(encoder.MaxRetrievable());
             encoder.Get(reinterpret_cast<byte*>(&encoded.front()), encoded.size());
             return std::make_optional(encoded);
         }
         return std::nullopt;
     }
-}
+} // namespace crypto

--- a/src/crypto/password.cpp
+++ b/src/crypto/password.cpp
@@ -11,14 +11,13 @@ namespace crypto
     password::password(const std::string_view pass_str)
         : mHash(this->hash_password(pass_str))
     {
-
     }
 
     std::string password::hash_password(const std::string_view pass_str) const
     {
-        const std::string pass{std::string(pass_str) + mSalt};
-        const std::span<const uint8_t> pass_span{reinterpret_cast<const uint8_t*>(pass.data()), pass.size()};
-        const auto val{crypto::md5_digest(pass_span)};
+        const std::string pass { std::string(pass_str) + mSalt };
+        const std::span<const uint8_t> pass_span { reinterpret_cast<const uint8_t*>(pass.data()), pass.size() };
+        const auto val { crypto::md5_digest(pass_span) };
         if (!val)
         {
             throw std::runtime_error("Could not hash password");
@@ -26,9 +25,9 @@ namespace crypto
         return *val;
     }
 
-    std::string password::generate_salt() const
+    std::string password::generate_salt()
     {
-        const auto now{std::chrono::steady_clock::now()};
+        const auto now { std::chrono::steady_clock::now() };
         return std::to_string(now.time_since_epoch().count());
     }
-}
+} // namespace crypto

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include "ui/album_view.hpp"
 #include "ui/debug_view.hpp"
 #include "ui/login_component.hpp"
 #include "oss/server_config.hpp"
@@ -19,6 +20,12 @@ int main()
 
     if (!config.password)
         return 1;
+
+    ui::album_view album{screen, config};
+    auto album_renderer = ftxui::Renderer(album.component(), [&]{
+        return album.render();
+    });
+    screen.Loop(album_renderer);
 
     ui::debug_view debug{screen, config};
     auto debug_renderer = ftxui::Renderer(debug.component(), [&]{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,19 +1,17 @@
+#include "oss/server_config.hpp"
 #include "ui/album_view.hpp"
 #include "ui/login_component.hpp"
-#include "oss/server_config.hpp"
 
 import nlohmann.json;
 import ftxui;
 
 int main()
 {
-    oss::server_config config{"", ""};
-    auto screen{ftxui::ScreenInteractive::Fullscreen()};
+    oss::server_config config { "", "" };
+    auto screen { ftxui::ScreenInteractive::Fullscreen() };
 
-    ui::login_component login{screen, config};
-    auto login_renderer = ftxui::Renderer(login.component(), [&]{
-        return login.render();
-    });
+    ui::login_component login { screen, config };
+    auto login_renderer = ftxui::Renderer(login.component(), [&] { return login.render(); });
 
     screen.Loop(login_renderer);
 
@@ -22,7 +20,7 @@ int main()
         return 1;
     }
 
-    ui::album_view album{screen, config};
+    ui::album_view album { screen, config };
     screen.Loop(album.render());
 
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,4 @@
 #include "ui/album_view.hpp"
-#include "ui/debug_view.hpp"
 #include "ui/login_component.hpp"
 #include "oss/server_config.hpp"
 
@@ -25,12 +24,6 @@ int main()
 
     ui::album_view album{screen, config};
     screen.Loop(album.render());
-
-    ui::debug_view debug{screen, config};
-    auto debug_renderer = ftxui::Renderer(debug.component(), [&]{
-        return debug.render();
-    });
-    screen.Loop(debug_renderer);
 
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,10 +22,7 @@ int main()
         return 1;
 
     ui::album_view album{screen, config};
-    auto album_renderer = ftxui::Renderer(album.component(), [&]{
-        return album.render();
-    });
-    screen.Loop(album_renderer);
+    screen.Loop(album.render());
 
     ui::debug_view debug{screen, config};
     auto debug_renderer = ftxui::Renderer(debug.component(), [&]{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,9 @@ int main()
     screen.Loop(login_renderer);
 
     if (!config.password)
+    {
         return 1;
+    }
 
     ui::album_view album{screen, config};
     screen.Loop(album.render());

--- a/src/oss/data/subsonic_response.cpp
+++ b/src/oss/data/subsonic_response.cpp
@@ -6,103 +6,115 @@ namespace oss::data
     // subsonic_error
     //
 
-    void to_json(json& j, const subsonic_error& err)
+    void to_json(json& obj, const subsonic_error& err)
     {
-        j = json {
+        obj = json {
             { "code", err.code },
             { "message", err.message },
         };
     }
 
-    void from_json(const json& j, subsonic_error& err)
+    void from_json(const json& obj, subsonic_error& err)
     {
-        j.at("code").get_to(err.code);
-        if (j.contains("message"))
-            j.at("message").get_to(err.message);
+        obj.at("code").get_to(err.code);
+        if (obj.contains("message"))
+        {
+            obj.at("message").get_to(err.message);
+        }
     }
 
     //
     // subsonic_response
     //
 
-    void to_json(json& j, const subsonic_response& p)
+    void to_json(json& obj, const subsonic_response& res)
     {
-        j = json {
-            { "status", p.status },
-            { "version", p.version },
-            { "type", p.type },
-            { "serverVersion", p.serverVersion },
-            { "openSubsonic", p.openSubsonic },
-            { "error", p.error },
+        obj = json {
+            { "status", res.status },
+            { "version", res.version },
+            { "type", res.type },
+            { "serverVersion", res.serverVersion },
+            { "openSubsonic", res.openSubsonic },
+            { "error", res.error },
         };
     }
-    void from_json(const json& j, subsonic_response& p)
+    void from_json(const json& obj, subsonic_response& res)
     {
-        j.at("status").get_to(p.status);
-        j.at("version").get_to(p.version);
-        j.at("type").get_to(p.type);
-        j.at("serverVersion").get_to(p.serverVersion);
-        j.at("openSubsonic").get_to(p.openSubsonic);
-        if (j.contains("error"))
-            j.at("error").get_to(p.error);
+        obj.at("status").get_to(res.status);
+        obj.at("version").get_to(res.version);
+        obj.at("type").get_to(res.type);
+        obj.at("serverVersion").get_to(res.serverVersion);
+        obj.at("openSubsonic").get_to(res.openSubsonic);
+        if (obj.contains("error"))
+        {
+            obj.at("error").get_to(res.error);
+        }
     }
 
     //
     // music_folder
     //
 
-    void to_json(json& j, const music_folder& m)
+    void to_json(json& obj, const music_folder& mfolder)
     {
-        j = json {
-            { "id", m.id },
-            { "name", m.name },
+        obj = json {
+            { "id", mfolder.id },
+            { "name", mfolder.name },
         };
     }
-    void from_json(const json& j, music_folder& m)
+    void from_json(const json& obj, music_folder& mfolder)
     {
-        j.at("id").get_to(m.id);
-        j.at("name").get_to(m.name);
+        obj.at("id").get_to(mfolder.id);
+        obj.at("name").get_to(mfolder.name);
     }
 
     //
     // music_folder_response
     //
 
-    void from_json(const json& j, music_folder_response& m)
+    void from_json(const json& obj, music_folder_response& res)
     {
-        nlohmann::from_json(j, static_cast<subsonic_response&>(m));
-        if (j.contains("musicFolders"))
-            j.at("musicFolders").at("musicFolder").get_to(m.music_folders);
+        nlohmann::from_json(obj, static_cast<subsonic_response&>(res));
+        if (obj.contains("musicFolders"))
+        {
+            obj.at("musicFolders").at("musicFolder").get_to(res.music_folders);
+        }
     }
 
-    void from_json(const json& j, music_track& m)
+    void from_json(const json& obj, music_track& track)
     {
-        j.at("id").get_to(m.id);
-        j.at("title").get_to(m.title);
+        obj.at("id").get_to(track.id);
+        obj.at("title").get_to(track.title);
     }
 
-    void from_json(const json& j, album_list& a)
+    void from_json(const json& obj, album_list& album)
     {
-        j.at("album").get_to(a.album);
+        obj.at("album").get_to(album.album);
     }
 
-    void from_json(const json& j, album_list_response& a)
+    void from_json(const json& obj, album_list_response& res)
     {
-        nlohmann::from_json(j, static_cast<subsonic_response&>(a));
-        if (j.contains("albumList"))
-            j.at("albumList").get_to(a.album_list);
+        nlohmann::from_json(obj, static_cast<subsonic_response&>(res));
+        if (obj.contains("albumList"))
+        {
+            obj.at("albumList").get_to(res.album_list);
+        }
     }
 
-    void from_json(const json& j, album_id3& a)
+    void from_json(const json& obj, album_id3& aid)
     {
-        if (j.contains("song"))
-            j.at("song").get_to(a.children);
+        if (obj.contains("song"))
+        {
+            obj.at("song").get_to(aid.children);
+        }
     }
 
-    void from_json(const json& j, album_response& a)
+    void from_json(const json& obj, album_response& res)
     {
-        nlohmann::from_json(j, static_cast<subsonic_response&>(a));
-        if (j.contains("album"))
-            j.at("album").get_to(a.album);
+        nlohmann::from_json(obj, static_cast<subsonic_response&>(res));
+        if (obj.contains("album"))
+        {
+            obj.at("album").get_to(res.album);
+        }
     }
 } // namespace oss::data

--- a/src/oss/data/subsonic_response.cpp
+++ b/src/oss/data/subsonic_response.cpp
@@ -79,4 +79,16 @@ namespace oss::data
     {
         j.at("title").get_to(m.title);
     }
+
+    void from_json(const json& j, album_list& a)
+    {
+        j.at("album").get_to(a.album);
+    }
+
+    void from_json(const json& j, album_list_response& a)
+    {
+        nlohmann::from_json(j, static_cast<subsonic_response&>(a));
+        if (j.contains("albumList"))
+            j.at("albumList").get_to(a.album_list);
+    }
 }

--- a/src/oss/data/subsonic_response.cpp
+++ b/src/oss/data/subsonic_response.cpp
@@ -95,7 +95,8 @@ namespace oss::data
 
     void from_json(const json& j, album_id3& a)
     {
-        j.at("song").get_to(a.children);
+        if (j.contains("song"))
+            j.at("song").get_to(a.children);
     }
 
     void from_json(const json& j, album_response& a)

--- a/src/oss/data/subsonic_response.cpp
+++ b/src/oss/data/subsonic_response.cpp
@@ -77,6 +77,7 @@ namespace oss::data
 
     void from_json(const json& j, music_track& m)
     {
+        j.at("id").get_to(m.id);
         j.at("title").get_to(m.title);
     }
 

--- a/src/oss/data/subsonic_response.cpp
+++ b/src/oss/data/subsonic_response.cpp
@@ -8,9 +8,9 @@ namespace oss::data
 
     void to_json(json& j, const subsonic_error& err)
     {
-        j = json{
-            {"code", err.code},
-            {"message", err.message},
+        j = json {
+            { "code", err.code },
+            { "message", err.message },
         };
     }
 
@@ -27,13 +27,13 @@ namespace oss::data
 
     void to_json(json& j, const subsonic_response& p)
     {
-        j = json{
-            {"status", p.status},
-            {"version", p.version},
-            {"type", p.type},
-            {"serverVersion", p.serverVersion},
-            {"openSubsonic", p.openSubsonic},
-            {"error", p.error}
+        j = json {
+            { "status", p.status },
+            { "version", p.version },
+            { "type", p.type },
+            { "serverVersion", p.serverVersion },
+            { "openSubsonic", p.openSubsonic },
+            { "error", p.error },
         };
     }
     void from_json(const json& j, subsonic_response& p)
@@ -53,9 +53,9 @@ namespace oss::data
 
     void to_json(json& j, const music_folder& m)
     {
-        j = json{
-            {"id", m.id},
-            {"name", m.name}
+        j = json {
+            { "id", m.id },
+            { "name", m.name },
         };
     }
     void from_json(const json& j, music_folder& m)
@@ -92,4 +92,16 @@ namespace oss::data
         if (j.contains("albumList"))
             j.at("albumList").get_to(a.album_list);
     }
-}
+
+    void from_json(const json& j, album_id3& a)
+    {
+        j.at("song").get_to(a.children);
+    }
+
+    void from_json(const json& j, album_response& a)
+    {
+        nlohmann::from_json(j, static_cast<subsonic_response&>(a));
+        if (j.contains("album"))
+            j.at("album").get_to(a.album);
+    }
+} // namespace oss::data

--- a/src/oss/endpoints.cpp
+++ b/src/oss/endpoints.cpp
@@ -33,4 +33,23 @@ namespace oss
         const auto body(json::parse(res.text));
         return body.at("subsonic-response").template get<oss::data::music_folder_response>();
     }
+
+    std::optional<data::album_list_response> getAlbumList(const server_config& config)
+    {
+        auto params{*config.parameters};
+        params.Add(
+            {
+                {"type", "newest"},
+                {"size", "25"}
+            }
+        );
+        const auto res{cpr::Get(cpr::Url(config.url_string  + "/rest/getAlbumList.view"), params)};
+        if (res.error)
+        {
+            return std::nullopt;
+        }
+
+        const auto body(json::parse(res.text));
+        return body.at("subsonic-response").template get<oss::data::album_list_response>();
+    }
 }

--- a/src/oss/endpoints.cpp
+++ b/src/oss/endpoints.cpp
@@ -75,17 +75,18 @@ namespace oss
         sessions.reserve(albums_list.size());
         cpr::MultiPerform multi {};
 
-        std::ranges::for_each(albums_list, [&config, &uri, &sessions](const auto& album)
-        {
-            auto session { std::make_shared<cpr::Session>() };
-            auto params { *config.parameters };
-            params.Add({
-                { "id", album.id },
-            });
-            session->SetUrl(uri);
-            session->SetParameters(params);
-            sessions.emplace_back(std::move(session));
-        });
+        std::ranges::for_each(albums_list,
+                              [&config, &uri, &sessions](const auto& album)
+                              {
+                                  auto session { std::make_shared<cpr::Session>() };
+                                  auto params { *config.parameters };
+                                  params.Add({
+                                      { "id", album.id },
+                                  });
+                                  session->SetUrl(uri);
+                                  session->SetParameters(params);
+                                  sessions.emplace_back(std::move(session));
+                              });
 
         for (auto& session : sessions)
         {
@@ -94,20 +95,21 @@ namespace oss
 
         const auto responses { multi.Get() };
         std::vector<data::album_response> song_responses {};
-        std::ranges::transform(
-            std::views::filter(responses, [](const auto& res){
-                if (res.error)
-                {
-                    std::cerr << "ERROR: " << res.error.message << "\n";
-                }
-                return !res.error;
-            }),
-            std::back_inserter(song_responses),
-            [](const auto& res){
-                const auto body(json::parse(res.text));
-                return body.at("subsonic-response").template get<oss::data::album_response>();
-            }
-        );
+        std::ranges::transform(std::views::filter(responses,
+                                                  [](const auto& res)
+                                                  {
+                                                      if (res.error)
+                                                      {
+                                                          std::cerr << "ERROR: " << res.error.message << "\n";
+                                                      }
+                                                      return !res.error;
+                                                  }),
+                               std::back_inserter(song_responses),
+                               [](const auto& res)
+                               {
+                                   const auto body(json::parse(res.text));
+                                   return body.at("subsonic-response").template get<oss::data::album_response>();
+                               });
         return song_responses;
     }
 } // namespace oss

--- a/src/oss/endpoints.cpp
+++ b/src/oss/endpoints.cpp
@@ -66,15 +66,16 @@ namespace oss
         return body.at("subsonic-response").template get<oss::data::album_response>();
     }
 
-    std::optional<std::vector<data::album_response>> getAlbum(const server_config& config, const std::vector<data::music_track>& albums_list)
+    std::optional<std::vector<data::album_response>> getAlbum(const server_config& config,
+                                                              const std::vector<data::music_track>& albums_list)
     {
         cpr::Url uri(config.url_string + "/rest/getAlbum.view");
-        std::vector<std::shared_ptr<cpr::Session>> sessions{};
-        cpr::MultiPerform mp{};
+        std::vector<std::shared_ptr<cpr::Session>> sessions {};
+        cpr::MultiPerform multi {};
 
         for (const auto& album : albums_list)
         {
-            auto session{std::make_shared<cpr::Session>()};
+            auto session { std::make_shared<cpr::Session>() };
             auto params { *config.parameters };
             params.Add({
                 { "id", album.id },
@@ -86,12 +87,11 @@ namespace oss
 
         for (auto& session : sessions)
         {
-            mp.AddSession(session);
+            multi.AddSession(session);
         }
 
-
-        const auto responses{mp.Get()};
-        std::vector<data::album_response> song_responses{};
+        const auto responses { multi.Get() };
+        std::vector<data::album_response> song_responses {};
         for (const auto& res : responses)
         {
             if (res.error)

--- a/src/oss/endpoints.cpp
+++ b/src/oss/endpoints.cpp
@@ -6,50 +6,59 @@ import nlohmann.json;
 namespace oss
 {
     using nlohmann::json;
-    std::optional<data::subsonic_response> ping(const server_config& config) try
+    std::optional<data::subsonic_response> ping(const server_config& config)
+    try
     {
-        const auto res{cpr::Get(cpr::Url(config.url_string  + "/rest/ping.view"), *config.parameters)};
-
+        const auto res { cpr::Get(cpr::Url(config.url_string + "/rest/ping.view"), *config.parameters) };
         if (res.error)
         {
             return std::nullopt;
         }
-
         const auto body(json::parse(res.text));
         return body.at("subsonic-response").template get<oss::data::subsonic_response>();
-    } catch (const std::exception& ex)
+    }
+    catch (const std::exception& ex)
     {
         return std::nullopt;
     }
 
     std::optional<data::music_folder_response> getMusicFolders(const server_config& config)
     {
-        const auto res{cpr::Get(cpr::Url(config.url_string  + "/rest/getMusicFolders.view"), *config.parameters)};
+        const auto res { cpr::Get(cpr::Url(config.url_string + "/rest/getMusicFolders.view"), *config.parameters) };
         if (res.error)
         {
             return std::nullopt;
         }
-
         const auto body(json::parse(res.text));
         return body.at("subsonic-response").template get<oss::data::music_folder_response>();
     }
 
     std::optional<data::album_list_response> getAlbumList(const server_config& config)
     {
-        auto params{*config.parameters};
-        params.Add(
-            {
-                {"type", "newest"},
-                {"size", "25"}
-            }
-        );
-        const auto res{cpr::Get(cpr::Url(config.url_string  + "/rest/getAlbumList.view"), params)};
+        auto params { *config.parameters };
+        params.Add({ { "type", "newest" }, { "size", "25" } });
+        const auto res { cpr::Get(cpr::Url(config.url_string + "/rest/getAlbumList.view"), params) };
+        if (res.error)
+        {
+            return std::nullopt;
+        }
+        const auto body(json::parse(res.text));
+        return body.at("subsonic-response").template get<oss::data::album_list_response>();
+    }
+
+    std::optional<data::album_response> getAlbum(const server_config& config, const std::string& album_id)
+    {
+        auto params { *config.parameters };
+        params.Add({
+            { "id", album_id },
+        });
+        const auto res { cpr::Get(cpr::Url(config.url_string + "/rest/getAlbum.view"), params) };
         if (res.error)
         {
             return std::nullopt;
         }
 
         const auto body(json::parse(res.text));
-        return body.at("subsonic-response").template get<oss::data::album_list_response>();
+        return body.at("subsonic-response").template get<oss::data::album_response>();
     }
-}
+} // namespace oss

--- a/src/oss/server_config.cpp
+++ b/src/oss/server_config.cpp
@@ -1,33 +1,40 @@
 #include "oss/server_config.hpp"
 #include "oss/endpoints.hpp"
+#include <format>
 #include <memory>
 #include <optional>
+#include <utility>
 
 import nlohmann.json;
 
 namespace oss
 {
-    server_config::server_config(const std::string& user, const std::string& url)
-        : url_string{url},  user{user}
+    server_config::server_config(std::string user, std::string url)
+        : url_string { std::move(url) }
+        , user { std::move(user) }
     {
     }
 
     std::optional<std::string> server_config::login()
     {
         if (!parameters)
+        {
             parameters = std::make_unique<cpr::Parameters>();
+        }
 
-        parameters->Add({"v","1.1"});
-        parameters->Add({"f","json"});
-        parameters->Add({"c",std::string(client_id)});
-        parameters->Add({"u",user});
+        parameters->Add({ "v", "1.1" });
+        parameters->Add({ "f", "json" });
+        parameters->Add({ "c", std::string(client_id) });
+        parameters->Add({ "u", user });
         if (!password)
+        {
             return std::make_optional("No Password!");
+        }
 
-        parameters->Add({"s",password->salt()});
-        parameters->Add({"t",password->hash()});
+        parameters->Add({ "s", password->salt() });
+        parameters->Add({ "t", password->hash() });
 
-        const auto response{oss::ping(*this)};
+        const auto response { oss::ping(*this) };
         if (!response.has_value())
         {
             parameters.reset();
@@ -36,10 +43,10 @@ namespace oss
 
         if (response->error.has_value())
         {
-            return *response->error->message;
+            return response->error->message.value_or(
+                std::format("Got error code from server: {}", response->error->code));
         }
 
         return std::nullopt;
     }
-}
-
+} // namespace oss

--- a/src/ui/album_view.cpp
+++ b/src/ui/album_view.cpp
@@ -1,0 +1,72 @@
+#include "ui/album_view.hpp"
+#include "oss/endpoints.hpp"
+import ftxui;
+
+namespace ui
+{
+    album_view::album_view(ftxui::ScreenInteractive& screen, oss::server_config& config)
+        : mScreen { &screen }
+        , mConfig { &config }
+    {
+    }
+
+    std::vector<std::string> album_view::get_albums()
+    {
+        const auto res { oss::getAlbumList(*mConfig) };
+        std::vector<std::string> albums{};
+        if (!res.has_value())
+        {
+            return {};
+        }
+
+        if (res->error.has_value())
+        {
+            return {};
+        }
+
+        if (res->album_list.has_value())
+        {
+            albums.reserve(res->album_list->album.size());
+            for (const auto& album : res->album_list->album)
+            {
+                albums.emplace_back(album.title);
+            }
+        }
+        return albums;
+    }
+
+    std::vector<std::vector<std::string>> album_view::get_albums_tracks()
+    {
+        const auto res { oss::getAlbumList(*mConfig) };
+        std::vector<std::vector<std::string>> album_tracks{};
+        if (!res.has_value())
+        {
+            return {};
+        }
+
+        if (res->error.has_value())
+        {
+            return {};
+        }
+
+        if (res->album_list.has_value())
+        {
+            album_tracks.reserve(res->album_list->album.size());
+            for ([[maybe_unused]] const auto& album : res->album_list->album)
+            {
+                std::vector<std::string> tracks{};
+            }
+        }
+        return album_tracks;
+
+    }
+
+    ftxui::Element album_view::render()
+    {
+        return ftxui::vbox({
+            ftxui::text("Albums"),
+            ftxui::separator(),
+            mContainer->Render()
+        }) | ftxui::border;
+    }
+} // namespace ui

--- a/src/ui/album_view.cpp
+++ b/src/ui/album_view.cpp
@@ -16,7 +16,7 @@ namespace ui
     std::vector<std::string> album_view::get_albums()
     {
         const auto res { oss::getAlbumList(*mConfig) };
-        std::vector<std::string> albums{};
+        std::vector<std::string> albums {};
         if (!res.has_value())
         {
             return {};
@@ -40,9 +40,9 @@ namespace ui
 
     std::vector<std::vector<std::string>> album_view::get_albums_tracks()
     {
-        const auto t1{std::chrono::high_resolution_clock::now()};
+        const auto time1 { std::chrono::high_resolution_clock::now() };
         const auto res { oss::getAlbumList(*mConfig) };
-        std::vector<std::vector<std::string>> album_tracks{};
+        std::vector<std::vector<std::string>> album_tracks {};
         if (!res.has_value())
         {
             return {};
@@ -55,14 +55,14 @@ namespace ui
 
         if (res->album_list.has_value())
         {
-            const auto track_responses{oss::getAlbum(*mConfig, res->album_list->album)};
+            const auto track_responses { oss::getAlbum(*mConfig, res->album_list->album) };
             if (!track_responses.has_value())
             {
                 return {};
             }
             for ([[maybe_unused]] const auto& album : *track_responses)
             {
-                std::vector<std::string> tracks{};
+                std::vector<std::string> tracks {};
                 if (album.error.has_value())
                 {
                     return {};
@@ -75,32 +75,32 @@ namespace ui
                         {
                             tracks.emplace_back(track.title);
                         }
-                    } else
-                    {
                     }
+                    else { }
                 }
                 album_tracks.emplace_back(std::move(tracks));
             }
         }
 
-        const auto t2{std::chrono::high_resolution_clock::now()};
-        std::chrono::duration<double, std::milli> ms_double{t2 - t1};
-        std::chrono::duration<double> s_double{t2 - t1};
+        const auto time2 { std::chrono::high_resolution_clock::now() };
+        const std::chrono::duration<double, std::milli> ms_double { time2 - time1 };
+        const std::chrono::duration<double> s_double { time2 - time1 };
         std::cout << std::format("Album Fetch took: {}s/{}ms\n", s_double.count(), ms_double.count());
         return album_tracks;
     }
 
     ftxui::Component album_view::render()
     {
-        return ftxui::Renderer(mContainer, [&]{
-            return ftxui::vbox({
-                ftxui::text("Albums"),
-                ftxui::separator(),
-                ftxui::hbox({
-                    mAlbumMenu->Render()| ftxui::yframe | ftxui::yflex,
-                    mTrackMenu->Render() | ftxui::xflex,
-                })
-            }) | ftxui::border;
-        });
+        return ftxui::Renderer(mContainer,
+                               [&]
+                               {
+                                   return ftxui::vbox({ ftxui::text("Albums"),
+                                                        ftxui::separator(),
+                                                        ftxui::hbox({
+                                                            mAlbumMenu->Render() | ftxui::yframe | ftxui::yflex,
+                                                            mTrackMenu->Render() | ftxui::xflex,
+                                                        }) })
+                                          | ftxui::border;
+                               });
     }
 } // namespace ui

--- a/src/ui/album_view.cpp
+++ b/src/ui/album_view.cpp
@@ -1,5 +1,8 @@
 #include "ui/album_view.hpp"
 #include "oss/endpoints.hpp"
+#include <chrono>
+#include <iostream>
+#include <ratio>
 import ftxui;
 
 namespace ui
@@ -37,6 +40,7 @@ namespace ui
 
     std::vector<std::vector<std::string>> album_view::get_albums_tracks()
     {
+        const auto t1{std::chrono::high_resolution_clock::now()};
         const auto res { oss::getAlbumList(*mConfig) };
         std::vector<std::vector<std::string>> album_tracks{};
         if (!res.has_value())
@@ -51,22 +55,52 @@ namespace ui
 
         if (res->album_list.has_value())
         {
-            album_tracks.reserve(res->album_list->album.size());
-            for ([[maybe_unused]] const auto& album : res->album_list->album)
+            const auto track_responses{oss::getAlbum(*mConfig, res->album_list->album)};
+            if (!track_responses.has_value())
+            {
+                return {};
+            }
+            for ([[maybe_unused]] const auto& album : *track_responses)
             {
                 std::vector<std::string> tracks{};
+                if (album.error.has_value())
+                {
+                    return {};
+                }
+                if (album.album.has_value())
+                {
+                    if (album.album->children.has_value())
+                    {
+                        for (const auto& track : *album.album->children)
+                        {
+                            tracks.emplace_back(track.title);
+                        }
+                    } else
+                    {
+                    }
+                }
+                album_tracks.emplace_back(std::move(tracks));
             }
         }
-        return album_tracks;
 
+        const auto t2{std::chrono::high_resolution_clock::now()};
+        std::chrono::duration<double, std::milli> ms_double{t2 - t1};
+        std::chrono::duration<double> s_double{t2 - t1};
+        std::cout << std::format("Album Fetch took: {}s/{}ms\n", s_double.count(), ms_double.count());
+        return album_tracks;
     }
 
-    ftxui::Element album_view::render()
+    ftxui::Component album_view::render()
     {
-        return ftxui::vbox({
-            ftxui::text("Albums"),
-            ftxui::separator(),
-            mContainer->Render()
-        }) | ftxui::border;
+        return ftxui::Renderer(mContainer, [&]{
+            return ftxui::vbox({
+                ftxui::text("Albums"),
+                ftxui::separator(),
+                ftxui::hbox({
+                    mAlbumMenu->Render()| ftxui::yframe | ftxui::yflex,
+                    mTrackMenu->Render() | ftxui::xflex,
+                })
+            }) | ftxui::border;
+        });
     }
 } // namespace ui

--- a/src/ui/album_view.cpp
+++ b/src/ui/album_view.cpp
@@ -42,7 +42,6 @@ namespace ui
 
     std::vector<std::vector<std::string>> album_view::get_albums_tracks()
     {
-        const auto time1 { std::chrono::high_resolution_clock::now() };
         const auto res { oss::getAlbumList(*mConfig) };
         std::vector<std::vector<std::string>> album_tracks {};
         if (!res.has_value())
@@ -101,10 +100,6 @@ namespace ui
             );
         }
 
-        const auto time2 { std::chrono::high_resolution_clock::now() };
-        const std::chrono::duration<double, std::milli> ms_double { time2 - time1 };
-        const std::chrono::duration<double> s_double { time2 - time1 };
-        std::cout << std::format("Album Fetch took: {}s/{}ms\n", s_double.count(), ms_double.count());
         return album_tracks;
     }
 

--- a/src/ui/album_view.cpp
+++ b/src/ui/album_view.cpp
@@ -63,41 +63,42 @@ namespace ui
             {
                 return {};
             }
-            std::ranges::transform(
-                std::views::filter(*track_responses, [](const auto& album){
-                    if (album.error.has_value())
-                    {
-                        std::cerr << "ERROR: " << *album.error->message << "\n";
-                        return false;
-                    }
-                    if (!album.album.has_value())
-                    {
-                        std::cerr << "ERROR: No album\n";
-                        return false;
-                    }
-                    if (!album.album.has_value())
-                    {
-                        std::cerr << "ERROR: No album\n";
-                        return false;
-                    }
-                    if (!album.album->children.has_value())
-                    {
-                        std::cerr << "ERROR: No album children\n";
-                        return false;
-                    }
-                    return true;
-                }),
-                std::back_inserter(album_tracks),
-                [](const auto& album) {
-                    std::vector<std::string> tracks {};
-                    tracks.reserve(album.album->children->size());
-                    for (const auto& track : *album.album->children)
-                    {
-                        tracks.emplace_back(track.title);
-                    }
-                    return tracks;
-                }
-            );
+            std::ranges::transform(std::views::filter(*track_responses,
+                                                      [](const auto& album)
+                                                      {
+                                                          if (album.error.has_value())
+                                                          {
+                                                              std::cerr << "ERROR: " << *album.error->message << "\n";
+                                                              return false;
+                                                          }
+                                                          if (!album.album.has_value())
+                                                          {
+                                                              std::cerr << "ERROR: No album\n";
+                                                              return false;
+                                                          }
+                                                          if (!album.album.has_value())
+                                                          {
+                                                              std::cerr << "ERROR: No album\n";
+                                                              return false;
+                                                          }
+                                                          if (!album.album->children.has_value())
+                                                          {
+                                                              std::cerr << "ERROR: No album children\n";
+                                                              return false;
+                                                          }
+                                                          return true;
+                                                      }),
+                                   std::back_inserter(album_tracks),
+                                   [](const auto& album)
+                                   {
+                                       std::vector<std::string> tracks {};
+                                       tracks.reserve(album.album->children->size());
+                                       for (const auto& track : *album.album->children)
+                                       {
+                                           tracks.emplace_back(track.title);
+                                       }
+                                       return tracks;
+                                   });
         }
 
         return album_tracks;

--- a/src/ui/debug_view.cpp
+++ b/src/ui/debug_view.cpp
@@ -8,40 +8,31 @@ import ftxui;
 namespace ui
 {
     debug_view::debug_view(ftxui::ScreenInteractive& screen, oss::server_config& config)
-        : mConfig{&config}
-        , mScreen{&screen}
-        , mContainer(ftxui::Container::Vertical(
-            {
-                mPing,
-                mMusicFolders,
-                mAlbumList,
-                mQuit
-            } , &mIndex
-        ))
+        : mConfig { &config }
+        , mScreen { &screen }
+        , mContainer(ftxui::Container::Vertical({ mPing, mMusicFolders, mAlbumList, mQuit }, &mIndex))
     {
-
     }
 
     ftxui::Element debug_view::render()
     {
-        return ftxui::vbox({
-            ftxui::text("Debugging Page"),
-            ftxui::separator(),
-            ftxui::text(std::format("Connected to server: {}", mConfig->url_string)),
-            ftxui::text(std::format("User: {}", mConfig->user)),
-            ftxui::separator(),
-            ftxui::paragraph(mDebugText),
-            ftxui::separator(),
-            mPing->Render(),
-            mMusicFolders->Render(),
-            mAlbumList->Render(),
-            mQuit->Render()
-        }) | ftxui::border;
+        return ftxui::vbox({ ftxui::text("Debugging Page"),
+                             ftxui::separator(),
+                             ftxui::text(std::format("Connected to server: {}", mConfig->url_string)),
+                             ftxui::text(std::format("User: {}", mConfig->user)),
+                             ftxui::separator(),
+                             ftxui::paragraph(mDebugText),
+                             ftxui::separator(),
+                             mPing->Render(),
+                             mMusicFolders->Render(),
+                             mAlbumList->Render(),
+                             mQuit->Render() })
+               | ftxui::border;
     }
 
     void debug_view::ping()
     {
-        const auto response{oss::ping(*mConfig)};
+        const auto response { oss::ping(*mConfig) };
         if (!response.has_value())
         {
             mDebugText = "Could not reach server";
@@ -58,7 +49,7 @@ namespace ui
     }
     void debug_view::musicFolders()
     {
-        const auto response{oss::getMusicFolders(*mConfig)};
+        const auto response { oss::getMusicFolders(*mConfig) };
         if (!response.has_value())
         {
             mDebugText = "Could not reach server";
@@ -82,7 +73,7 @@ namespace ui
 
     void debug_view::albumList()
     {
-        const auto response{oss::getAlbumList(*mConfig)};
+        const auto response { oss::getAlbumList(*mConfig) };
         if (!response.has_value())
         {
             mDebugText = "Could not reach server";
@@ -102,8 +93,10 @@ namespace ui
             {
                 mDebugText += std::format("{}\n", album.title);
             }
-        } else {
+        }
+        else
+        {
             mDebugText = "Wo album?";
         }
     }
-}
+} // namespace ui

--- a/src/ui/debug_view.cpp
+++ b/src/ui/debug_view.cpp
@@ -14,6 +14,7 @@ namespace ui
             {
                 mPing,
                 mMusicFolders,
+                mAlbumList,
                 mQuit
             } , &mIndex
         ))
@@ -33,6 +34,7 @@ namespace ui
             ftxui::separator(),
             mPing->Render(),
             mMusicFolders->Render(),
+            mAlbumList->Render(),
             mQuit->Render()
         }) | ftxui::border;
     }
@@ -75,6 +77,33 @@ namespace ui
             {
                 mDebugText += std::format("{} - {}\n", folder.id, folder.name);
             }
+        }
+    }
+
+    void debug_view::albumList()
+    {
+        const auto response{oss::getAlbumList(*mConfig)};
+        if (!response.has_value())
+        {
+            mDebugText = "Could not reach server";
+            return;
+        }
+
+        if (response->error.has_value())
+        {
+            mDebugText = *response->error->message;
+            return;
+        }
+
+        if (response->album_list.has_value())
+        {
+            mDebugText = "";
+            for (const auto& album : response->album_list->album)
+            {
+                mDebugText += std::format("{}\n", album.title);
+            }
+        } else {
+            mDebugText = "Wo album?";
         }
     }
 }

--- a/src/ui/login_component.cpp
+++ b/src/ui/login_component.cpp
@@ -1,82 +1,75 @@
 #include "ui/login_component.hpp"
+#include "crypto/password.hpp"
 #include <cassert>
 #include <ftxui/component/component.hpp>
 #include <ftxui/dom/elements.hpp>
 #include <memory>
-#include "crypto/password.hpp"
 
 import ftxui;
 namespace ui
 {
     login_component::login_component(ftxui::ScreenInteractive& screen, oss::server_config& config)
         : mScreen(&screen)
-        , mConfig{&config}
-        , mSubmit{ftxui::Button("Submit", [&]{
-            try
-            {
-                mConfig->password = std::make_unique<crypto::password>(mPassword);
-                if (auto err{mConfig->login()})
-                {
-                    mConnection = false;
-                    serverText = std::format("Connection Failed: {}", *err);
-                    mConfig->password.reset();
-                } else {
-                    mConnection = true;
-                    mScreen->Exit();
-                }
-            } catch (const std::exception&)
-            {
-                serverText = "Connection Failed - could not hash password";
-            }
-        })}
+        , mConfig { &config }
+        , mSubmit { ftxui::Button("Submit",
+                                  [&]
+                                  {
+                                      try
+                                      {
+                                          mConfig->password = std::make_unique<crypto::password>(mPassword);
+                                          if (auto err { mConfig->login() })
+                                          {
+                                              mConnection = false;
+                                              serverText  = std::format("Connection Failed: {}", *err);
+                                              mConfig->password.reset();
+                                          }
+                                          else
+                                          {
+                                              mConnection = true;
+                                              mScreen->Exit();
+                                          }
+                                      }
+                                      catch (const std::exception&)
+                                      {
+                                          serverText = "Connection Failed - could not hash password";
+                                      }
+                                  }) }
         , mContainer(ftxui::Container::Vertical(
-            {
-                mURLInput,
-                mUserNameInput,
-                mPasswordInput,
-                ftxui::Container::Horizontal(
-                    {
-                        mSubmit,
-                        mQuit,
-                    }
-                    , &buttonIndex
-                ),
-            },
-            &index
-        ))
+              {
+                  mURLInput,
+                  mUserNameInput,
+                  mPasswordInput,
+                  ftxui::Container::Horizontal(
+                      {
+                          mSubmit,
+                          mQuit,
+                      },
+                      &buttonIndex),
+              },
+              &index))
     {
-
     }
 
     ftxui::Element login_component::render()
     {
-        const auto submit_color{mConnection ?
-            ftxui::Color::Green :
-            ftxui::Color::Red
-        };
-
-        return ftxui::vbox({
-            ftxui::text("SubSonic Server Configuration & Login"),
-            ftxui::separator(),
-            ftxui::hbox({
-                ftxui::text("URL:"),
-                mURLInput->Render(),
-            }),
-            ftxui::hbox({
-                ftxui::text("Username:"),
-                mUserNameInput->Render(),
-            }),
-            ftxui::hbox({
-                ftxui::text("Password:"),
-                mPasswordInput->Render(),
-            }),
-            ftxui::separator(),
-            ftxui::text(serverText),
-            ftxui::hbox({
-                mSubmit->Render() | ftxui::flex,
-                mQuit->Render()
-            })
-        }) | ftxui::borderStyled(submit_color);
+        const auto submit_color { mConnection ? ftxui::Color::Green : ftxui::Color::Red };
+        return ftxui::vbox({ ftxui::text("SubSonic Server Configuration & Login"),
+                             ftxui::separator(),
+                             ftxui::hbox({
+                                 ftxui::text("URL:"),
+                                 mURLInput->Render(),
+                             }),
+                             ftxui::hbox({
+                                 ftxui::text("Username:"),
+                                 mUserNameInput->Render(),
+                             }),
+                             ftxui::hbox({
+                                 ftxui::text("Password:"),
+                                 mPasswordInput->Render(),
+                             }),
+                             ftxui::separator(),
+                             ftxui::text(serverText),
+                             ftxui::hbox({ mSubmit->Render() | ftxui::flex, mQuit->Render() }) })
+               | ftxui::borderStyled(submit_color);
     }
-}
-
+} // namespace ui


### PR DESCRIPTION
We implement the first basic view of Albums - currently fetching the 25 newest
Albums. We are currently more or less performant as long as we keep fetches below
~100 Albums.

We also implement `clang-tidy` and `clang-format` to ensure stable code formatting.