### PR TITLE
Improv fetching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(sonicli
 include(FetchContent)
 
 set(NLOHMANN_JSON_BUILD_MODULES ON)
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
 FetchContent_Declare(nlohmann_json
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ext/json
     BINARY_DIR ${CMAKE_BINARY_DIR}/ext/json
@@ -88,3 +89,5 @@ target_compile_options(sonicli PRIVATE
     -Weffc++
     -Wno-missing-designated-field-initializers
 )
+
+set_property(TARGET sonicli PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)

--- a/inc/ui/album_view.hpp
+++ b/inc/ui/album_view.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "oss/data/subsonic_response.hpp"
 #include "oss/server_config.hpp"
 #include <ftxui/component/component_options.hpp>
 import ftxui;
@@ -14,13 +15,15 @@ namespace ui
     private:
         std::vector<std::string> get_albums();
         std::vector<std::vector<std::string>> get_albums_tracks();
+        std::vector<std::string> get_current_albums_tracks();
         [[maybe_unused]] ftxui::ScreenInteractive* mScreen { nullptr };
         oss::server_config* mConfig { nullptr };
 
         int mAlbumSelected { 0 };
         int mTrackSelected { 0 };
+        std::vector<oss::data::music_track> mAlbums{};
         std::vector<std::string> mAlbumTitles { get_albums() };
-        std::vector<std::vector<std::string>> mAlbumTracks { get_albums_tracks() };
+        std::vector<std::vector<std::string>> mAlbumTracks { get_current_albums_tracks() };
         std::vector<std::string> mCurrentAlbumTracks { mAlbumTracks[0] };
 
         ftxui::MenuOption albumOption { .entries   = &mAlbumTitles,
@@ -28,7 +31,7 @@ namespace ui
                                         .on_change = [&]()
                                         {
                                             mTrackSelected      = 0;
-                                            mCurrentAlbumTracks = mAlbumTracks[mAlbumSelected];
+                                            mCurrentAlbumTracks = get_current_albums_tracks();
                                         } };
         ftxui::Component mAlbumMenu { ftxui::Menu(albumOption) };
         ftxui::Component mTrackMenu { ftxui::Menu({ .entries = &mCurrentAlbumTracks, .selected = &mTrackSelected }) };

--- a/inc/ui/album_view.hpp
+++ b/inc/ui/album_view.hpp
@@ -2,6 +2,7 @@
 #include "oss/data/subsonic_response.hpp"
 #include "oss/server_config.hpp"
 #include <ftxui/component/component_options.hpp>
+#include <unordered_map>
 import ftxui;
 
 namespace ui
@@ -21,10 +22,10 @@ namespace ui
 
         int mAlbumSelected { 0 };
         int mTrackSelected { 0 };
-        std::vector<oss::data::music_track> mAlbums{};
+        std::vector<oss::data::music_track> mAlbums;
         std::vector<std::string> mAlbumTitles { get_albums() };
-        std::vector<std::vector<std::string>> mAlbumTracks { get_current_albums_tracks() };
-        std::vector<std::string> mCurrentAlbumTracks { mAlbumTracks[0] };
+        std::unordered_map<std::string, std::vector<oss::data::music_track>> mAlbumTracks;
+        std::vector<std::string> mCurrentAlbumTracks { get_current_albums_tracks() };
 
         ftxui::MenuOption albumOption { .entries   = &mAlbumTitles,
                                         .selected  = &mAlbumSelected,

--- a/src/oss/endpoints.cpp
+++ b/src/oss/endpoints.cpp
@@ -4,8 +4,12 @@
 #include "cpr/session.h"
 #include "oss/data/subsonic_response.hpp"
 #include <algorithm>
+#include <chrono>
 #include <cpr/cpr.h>
+#include <cpr/response.h>
+#include <cpr/timeout.h>
 #include <iostream>
+#include <iterator>
 import nlohmann.json;
 
 namespace oss
@@ -41,7 +45,7 @@ namespace oss
     std::optional<data::album_list_response> getAlbumList(const server_config& config)
     {
         auto params { *config.parameters };
-        params.Add({ { "type", "newest" }, { "size", "25" } });
+        params.Add({ { "type", "newest" }, { "size", "500" } });
         const auto res { cpr::Get(cpr::Url(config.url_string + "/rest/getAlbumList.view"), params) };
         if (res.error)
         {
@@ -93,7 +97,30 @@ namespace oss
             multi.AddSession(session);
         }
 
-        const auto responses { multi.Get() };
+        auto time2{std::chrono::steady_clock::now()};
+
+        std::shared_ptr<cpr::Session> session = std::make_shared<cpr::Session>();
+        std::vector<cpr::AsyncResponse> async_responses{};
+        std::ranges::for_each(albums_list,
+                [&async_responses, &uri, &config](const auto& album){
+                    auto params { *config.parameters };
+                    params.Add({
+                        { "id", album.id },
+                    });
+                    static constexpr int32_t timeout_ms{500};
+                    async_responses.emplace_back(cpr::GetAsync(uri, params, cpr::Timeout{timeout_ms}));
+                }
+        );
+        std::vector<cpr::Response> responses{};
+        std::ranges::transform(async_responses, std::back_inserter(responses), [](auto& album){
+            return album.get();
+        });
+
+        auto time2e{std::chrono::steady_clock::now()};
+        std::chrono::duration<double> diff2{time2e - time2};
+        std::cerr << std::format("Took2: {}s\n", diff2.count());
+
+
         std::vector<data::album_response> song_responses {};
         std::ranges::transform(std::views::filter(responses,
                                                   [](const auto& res)

--- a/src/ui/album_view.cpp
+++ b/src/ui/album_view.cpp
@@ -127,6 +127,13 @@ namespace ui
             std::cerr << "ERROR: " << *res->error->message << "\n";
             return {};
         }
+
+        if (!res->album.has_value() || !res->album->children.has_value())
+        {
+            std::cerr << "ERROR: no album children found!\n";
+            return {};
+        }
+
         std::vector<std::string> tracks_strings {};
         tracks_strings.reserve(res->album->children->size());
         for (const auto& track : *res->album->children)


### PR DESCRIPTION
Fetching is currently limited to 25 albums since we are attroviously slow fetching
both the Album and all of it's tracks at the same time. The idea will be the fetch
the tracks on-demand and cache them in a hash map.

Based off of #7

Signed-off-by: Sebastian Muxel <sebastian@muxel.dev>